### PR TITLE
fix: Switched the shell interpreter from `bash` to `sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed arq42 documentation to be updated to current application
+- Switched the shell interpreter from `bash` to `sh` in our scripts to enhance portability and reduce dependencies. 
+
 
 ## [1.2.0] - 2023-10-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,9 @@ COPY ./scripts/inject-dynamic-env.sh /docker-entrypoint.d/00-inject-dynamic-env.
 
 RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
 
-# Install bash and update vulnerable packages
+# Update vulnerable packages
 RUN apk update && \
-    apk add --no-cache bash
+    apk upgrade
 
 # Change ownership and switch back to nginx user
 RUN chown -R 101:101 /usr/share/nginx/html/

--- a/scripts/inject-dynamic-env.sh
+++ b/scripts/inject-dynamic-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 ###############################################################
 # Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -31,11 +31,11 @@ REACT_APP_COUNTRY_RISK_CLIENT_anchor='REACT_APP_COUNTRY_RISK_CLIENT:"country_ris
 
 index_html_reference=`cat /usr/share/nginx/html/index.html.reference`
 
-index_html=$(sed -r 's%'$REACT_APP_AUTH_URL_anchor'%'$custom_env_vars_REACT_APP_AUTH_URL'%g' <<< "$index_html_reference")
-index_html=$(sed -r 's%'$REACT_APP_COUNTRY_RISK_API_anchor'%'$custom_env_vars_REACT_APP_COUNTRY_RISK_API'%g' <<< "$index_html")
-index_html=$(sed -r 's%'$REACT_APP_PORTAL_FRONTEND_anchor'%'$custom_env_vars_REACT_APP_PORTAL_FRONTEND'%g' <<< "$index_html")
-index_html=$(sed -r 's%'$REACT_APP_PORTAL_BACKEND_anchor'%'$custom_env_vars_REACT_APP_PORTAL_BACKEND'%g' <<< "$index_html")
-index_html=$(sed -r 's%'$REACT_APP_COUNTRY_RISK_CLIENT_anchor'%'$custom_env_vars_REACT_APP_COUNTRY_RISK_CLIENT'%g' <<< "$index_html")
+index_html=$(echo "$index_html_reference" | sed -r 's%'$REACT_APP_AUTH_URL_anchor'%'$custom_env_vars_REACT_APP_AUTH_URL'%g')
+index_html=$(echo "$index_html" | sed -r 's%'$REACT_APP_COUNTRY_RISK_API_anchor'%'$custom_env_vars_REACT_APP_COUNTRY_RISK_API'%g')
+index_html=$(echo "$index_html" | sed -r 's%'$REACT_APP_PORTAL_FRONTEND_anchor'%'$custom_env_vars_REACT_APP_PORTAL_FRONTEND'%g')
+index_html=$(echo "$index_html" | sed -r 's%'$REACT_APP_PORTAL_BACKEND_anchor'%'$custom_env_vars_REACT_APP_PORTAL_BACKEND'%g')
+index_html=$(echo "$index_html" | sed -r 's%'$REACT_APP_COUNTRY_RISK_CLIENT_anchor'%'$custom_env_vars_REACT_APP_COUNTRY_RISK_CLIENT'%g')
 
 echo "$index_html"
 echo "$index_html" > /usr/share/nginx/html/index.html


### PR DESCRIPTION
<!-- 
fix: Switched the shell interpreter from `bash` to `sh`

-->

## Description
- Switched the shell interpreter from `bash` to `sh` in our scripts to enhance portability and reduce dependencies. This change helps ensure our scripts run reliably in environments where `bash` may not be available. All relevant scripts have been updated and tested to confirm compatibility with `sh`.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
