### PR TITLE
fix: Updated Arq42 and Changed Docker file Scripts

### DIFF
--- a/.github/workflows/docker-hub-build.yml
+++ b/.github/workflows/docker-hub-build.yml
@@ -1,0 +1,76 @@
+# Reference from https://github.com/eclipse-tractusx/app-dashboard/blob/main/.github/workflows/build-image.yaml
+# You might want to check the source for recent updates
+name: Build - Docker image (SemVer)
+
+on:
+  push:
+    branches:
+      - main
+    # trigger events for SemVer like tags
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  pull_request:
+    branches:
+      - main
+
+env:
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Create SemVer or ref tags dependent of trigger event
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          # Automatically prepare image tags; See action docs for more examples. 
+          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: DockerHub login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          # Use existing DockerHub credentials present as secrets
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ steps.meta.outputs.tags }},
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+
+
+      # https://github.com/peter-evans/dockerhub-description
+      # Important step to push image description to DockerHub 
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
+          # readme-filepath: path/to/dedicated/notice-for-docker-image.md
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-hub-build.yml
+++ b/.github/workflows/docker-hub-build.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   IMAGE_NAMESPACE: "tractusx"
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: "vas-country-risk"
 
 jobs:
   docker:


### PR DESCRIPTION
<!-- 
fix: Switched the shell interpreter from `bash` to `sh`

-->

## Description
- Switched the shell interpreter from `bash` to `sh` in our scripts to enhance portability and reduce dependencies. This change helps ensure our scripts run reliably in environments where `bash` may not be available. All relevant scripts have been updated and tested to confirm compatibility with `sh`.
- Updated arq42 documentation

Fixed for issues:
Arq42 dosc:  https://github.com/eclipse-tractusx/vas-country-risk-backend/issues/30 
Script change: https://github.com/eclipse-tractusx/vas-country-risk/issues/22

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
